### PR TITLE
Update using deprecated props

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,7 +1,10 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import htmlToElement from './htmlToElement';
-import {Linking, Platform, StyleSheet, View, ViewPropTypes} from 'react-native';
+import {Linking, Platform, StyleSheet, View } from 'react-native';
+import { import { ImagePropTypes, TextPropTypes } from 'deprecated-react-native-prop-types';
+ } from 'deprecated-react-native-prop-types';
+
 
 const boldStyle = {fontWeight: 'bold'};
 const italicStyle = {fontStyle: 'italic'};


### PR DESCRIPTION
React Native 0.70+ throws an error for any library still using a Prop from the base library.  Changed it to use the deprecated library to avoid crashing